### PR TITLE
Pee 1.1.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+# based on this article https://sergiodxa.com/articles/github-actions-npm-publish
+
+name: Publish
+
+on:
+  release:
+    types: [published] # this tells it to only publish when a new github release is made
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16 # current LTS
+          registry-url: https://registry.npmjs.org/
+      - run: npm install
+      - run: npm publish --access public
+        env:
+          # you have to set this in the github repository settings, you get it from the npm package settings
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+# based on wild guessing, might not work first try ngl
+
+name: Release
+
+on:
+  push:
+    branches:
+      - master # this tells it to run when commits are made to master
+
+jobs:
+  check_versions:
+    runs-on: ubuntu-latest
+    outputs: # this is kinda fucky in the way it works ngl
+      version: ${{ steps.check_versions.outputs.version }} # this uses the id from the step itself, not the job (they are the same)
+      continue: ${{ steps.check_versions.outputs.continue }}
+    steps:
+      - id: check_versions
+      - uses: actions/checkout@v2
+      - run: git describe --tags --abbrev=0 > /tmp/latest_tag # we get the latest tag and store it
+      - run: jq -r ".version" package.json > /tmp/current_version # we get the current package.json version and store it
+      - run: echo "::set-output name=version::$(cat /tmp/current_version)" # we set the current version as variable for the next job in case we continue 
+      # we compare the two version, if mismatch we want a new release (run next job), if not we dont run the next job
+      - run: cmp --silent /tmp/latest_tag /tmp/current_version && echo "::set-output name=continue::false" || echo "::set-output name=continue::true" 
+  release_on_bump:
+    needs: [check_versions]
+    if: needs.check_versions.outputs.continue == 'true' # this is uses the id from the job, not the step from the job (in case it changes)
+    runs-on: ubuntu-latest
+    seps:
+        uses: actions/checkout@v2
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ needs.check_versions.outputs.version }}
+          release_name: Release ${{ needs.check_versions.outputs.version }}
+          body: Release ${{ needs.check_versions.outputs.version }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/create-release@v1
-      - id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
       version: ${{ steps.check_versions.outputs.version }} # this uses the id from the step itself, not the job (they are the same)
       continue: ${{ steps.check_versions.outputs.continue }}
     steps:
-      - id: check_versions
       - uses: actions/checkout@v2
+      - id: check_versions
       - run: git describe --tags --abbrev=0 > /tmp/latest_tag # we get the latest tag and store it
       - run: jq -r ".version" package.json > /tmp/current_version # we get the current package.json version and store it
       - run: echo "::set-output name=version::$(cat /tmp/current_version)" # we set the current version as variable for the next job in case we continue 
@@ -26,9 +26,9 @@ jobs:
     if: needs.check_versions.outputs.continue == 'true' # this is uses the id from the job, not the step from the job (in case it changes)
     runs-on: ubuntu-latest
     steps:
-        uses: actions/checkout@v2
-        id: create_release
-        uses: actions/create-release@v1
+      - uses: actions/checkout@v2
+      - uses: actions/create-release@v1
+      - id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     needs: [check_versions]
     if: needs.check_versions.outputs.continue == 'true' # this is uses the id from the job, not the step from the job (in case it changes)
     runs-on: ubuntu-latest
-    seps:
+    steps:
         uses: actions/checkout@v2
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       continue: ${{ steps.check_versions.outputs.continue }}
     steps:
       - uses: actions/checkout@v2
-      - id: check_versions
+        id: check_versions
       - run: git describe --tags --abbrev=0 > /tmp/latest_tag # we get the latest tag and store it
       - run: jq -r ".version" package.json > /tmp/current_version # we get the current package.json version and store it
       - run: echo "::set-output name=version::$(cat /tmp/current_version)" # we set the current version as variable for the next job in case we continue 

--- a/README.md
+++ b/README.md
@@ -10,22 +10,38 @@ I wanted to make a JavaScript library named pee.js because of a typo and a pun.
 
 ## Usage
 
-### Browser (pee.js)
-```js
-import { leak } from './pee.js';
-leak(69); // Leaks 69 MB of memory
+This is a hybrid (commonjs and ecmascript module) package that is available on https://www.npmjs.com/package/pee.js
+```shell
+# To install the package in your project
+npm install --save pee.js
 ```
 
-### Node
-https://www.npmjs.com/package/pee.js
-```console
-npm install pee.js
-```
+### Browser [ecmascript] (pee.js)
 ```js
-const pee = require('pee.js');
-pee.leak(420);
+import { leak } from 'pee.js';
+leak(69); // Leaks 69 MB of memory
 ```
-See `test/test.node.js` for a more in-depth example
+See `test/pee.test.js` for a more in-depth example
+
+### Node [commonjs] (pee.cjs)
+```js
+const { leak } = require('pee.js');
+leak(420); // Leaks 420 MB of memory
+```
+See `test/pee.test.cjs` for a more in-depth example
+
+### Development
+Test suites are available for both the commonjs (using node env) and ecmascript (using jsdom env) version.
+```shell
+# To run both tests
+npm run test
+
+# To run commonjs tests
+npm run test:cjs
+
+# To run ecmascript tests
+npm run test:mjs
+```
 
 ## Why should I care?
 You should not. Thank you for your time.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pee.js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A javascript Library for leaking memory",
   "type": "module",
   "main": "pee.cjs",


### PR DESCRIPTION
Hello again,

- I have updated the docs to reflect the changes on how the packaging is done
- Create a github action to automatically make a new Github release / Git tag when the latest available git tag differs from the package.json version
- Create a github action to automatically publish the new Github releases on npm

:warning: **IMPORTANT BEFORE MERGING** :warning: 
1. you need to make the latest version of master a git tag

to do this from your local machine, make sure your HEAD on master is up to date with the HEAD on github

```shell
git tag 1.1.0
git push --tags
```
that will make the release script work as it works by checking the latest available tag on git and the package.json version and makes a release if there is a mismatch

the `GITHUB_TOKEN` is automatically made available by github you dont have to do anything for this one

2. you need to add the NPM token to the github repository settings 

see https://sergiodxa.com/articles/github-actions-npm-publish#configure-the-secret its pretty well explained step by step on there

the name should be the same as mentioned in the article `NPM_TOKEN`

**then should be good to merge**